### PR TITLE
Bundle the detekt-cli-all.jar file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,9 @@ FROM openjdk:jre-slim
 
 ADD https://github.com/detekt/detekt/releases/download/v1.15.0-RC2/detekt /usr/local/bin/detekt
 RUN chmod +x /usr/local/bin/detekt
+
+ADD https://github.com/detekt/detekt/releases/download/v1.15.0-RC2/detekt-cli-1.15.0-RC2-all.jar /usr/local/lib/detekt/detekt-cli-all.jar
+
 RUN cd $GITHUB_WORKSPACE
 
 ENTRYPOINT ["detekt"]


### PR DESCRIPTION
Not sure if this is necessary, given [this discussion](https://github.com/natiginfo/action-detekt-all/issues/14#issuecomment-746849660), but preparing it in case we need it.

I think the release script, `create_release.py`, will need to be modified as well.